### PR TITLE
Use index for labeling query

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You can do this on-the-fly in a TM2 SQL query, eg:
 ```sql
 ( SELECT ST_PointOnSurface(geom) AS geom, name
   FROM ne_10m_lakes
+  WHERE geom && !bbox!
 ) AS data
 ```
 


### PR DESCRIPTION
Without a manually specified && the query will essentially try to do ST_PointOnSurface(geom) && geom, which won't make use of normal indexes.
